### PR TITLE
Fix: Move appendHoverText mixin to client-only class to prevent dedicated server crash

### DIFF
--- a/src/main/java/it/hurts/sskirillss/relics/mixin/ItemClientMixin.java
+++ b/src/main/java/it/hurts/sskirillss/relics/mixin/ItemClientMixin.java
@@ -1,0 +1,36 @@
+package it.hurts.sskirillss.relics.mixin;
+
+import it.hurts.sskirillss.relics.api.relics.IRelicItem;
+import it.hurts.sskirillss.relics.init.RelicsHotkeys;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(Item.class)
+public class ItemClientMixin {
+	@Inject(method = "appendHoverText", at = @At("HEAD"))
+	public void appendHoverText(ItemStack stack, Item.TooltipContext context, List<Component> tooltip, TooltipFlag flag, CallbackInfo ci) {
+		Item item = stack.getItem();
+		
+		if (!(item instanceof IRelicItem))
+			return;
+		
+		tooltip.add(Component.literal(" "));
+		
+		if (Minecraft.getInstance().screen instanceof AbstractContainerScreen<? extends AbstractContainerMenu>)
+			tooltip.add(Component.translatable("relics.description.researching.info", RelicsHotkeys.RESEARCH_RELIC.getKey().getDisplayName()).withStyle(ChatFormatting.GRAY));
+
+        tooltip.add(Component.literal(" "));
+	}
+}

--- a/src/main/java/it/hurts/sskirillss/relics/mixin/ItemMixin.java
+++ b/src/main/java/it/hurts/sskirillss/relics/mixin/ItemMixin.java
@@ -51,27 +51,6 @@ public class ItemMixin {
             relicData.getStatisticData().getMetricData("retention_time").addValue(1);
     }
 
-    @Inject(method = "appendHoverText", at = @At("HEAD"))
-    public void appendHoverText(ItemStack stack, Item.TooltipContext context, List<Component> tooltip, TooltipFlag flag, CallbackInfo ci) {
-        relics$processTooltip(stack, context, tooltip);
-    }
-
-    @Unique
-    @OnlyIn(Dist.CLIENT)
-    private void relics$processTooltip(ItemStack stack, Item.TooltipContext context, List<Component> tooltip) {
-        Item item = stack.getItem();
-
-        if (!(item instanceof IRelicItem))
-            return;
-
-        tooltip.add(Component.literal(" "));
-
-        if (Minecraft.getInstance().screen instanceof AbstractContainerScreen<? extends AbstractContainerMenu>)
-            tooltip.add(Component.translatable("relics.description.researching.info", RelicsHotkeys.RESEARCH_RELIC.getKey().getDisplayName()).withStyle(ChatFormatting.GRAY));
-
-        tooltip.add(Component.literal(" "));
-    }
-
     // TODO: I think there should be less nulls :/
     @Inject(method = "verifyComponentsAfterLoad", at = @At("HEAD"))
     public void onVerifyComponentsAfterLoad(ItemStack stack, CallbackInfo ci) {

--- a/src/main/resources/relics.mixins.json
+++ b/src/main/resources/relics.mixins.json
@@ -22,6 +22,7 @@
     "CameraMixin",
     "GameRendererMixin",
     "GuiGraphicsMixin",
+    "ItemClientMixin",
     "ItemInHandRendererMixin",
     "ItemRendererMixin",
     "KeyboardHandlerMixin",


### PR DESCRIPTION
## Description
This PR fixes the dedicated server crash caused by the `appendHoverText` mixin in `ItemMixin` calling client-only code.

## Changes Made
- Created `ItemClientMixin` and moved the `appendHoverText` injection into it
- Registered `ItemClientMixin` in the `"client"` array of `mixins.json`
- Removed the client-side injection from `ItemMixin`

## Related Issue
Fixes #252 